### PR TITLE
prevent navigation links from always opening new tabs or windows

### DIFF
--- a/ConWiki/HTML/sidebar.html
+++ b/ConWiki/HTML/sidebar.html
@@ -15,11 +15,11 @@
       <!-- #################### ConWiki page navigation ####################-->
       <div id="page_nav">
         <h4> ConWiki Navigation </h4>
-        <a href="../homepage.html" target="_blank"> Home </a>
+        <a href="../homepage.html" target="_parent"> Home </a>
         </br>
-        <a href="help.html" target="_blank"> Help </a>
+        <a href="help.html" target="_parent"> Help </a>
         </br>
-        <a href="about.html" target="_blank"> About </a>
+        <a href="about.html" target="_parent"> About </a>
 
       </div>
 

--- a/ConWiki/HTML/topbar.html
+++ b/ConWiki/HTML/topbar.html
@@ -12,7 +12,7 @@
            onmouseout='this.src="../Media/ConWiki/search_btn_unhover.png"'>
 
       <button type="button" id="edit_btn">Edit</button>
-      <a href="create.html" target="_blank"><button type="button" id="create_btn">Create</button></a>
+      <a href="create.html" target="_parent"><button type="button" id="create_btn">Create</button></a>
     </div>
   </body>
 </html>


### PR DESCRIPTION
This change prevents the topbar and sidebar from always opening an entirely new tab or window