### PR TITLE
treat “GitHub” as a proper noun

### DIFF
--- a/ConWiki/HTML/help.html
+++ b/ConWiki/HTML/help.html
@@ -45,13 +45,13 @@ add style to the article with ConWiki's styling syntax.
         <h2> Report A Problem </h2>
         <pre>
 If during your time on ConWiki you encounter any problems,
-you can report them by visiting this <a href="https://github.com/RalphBayer/ConWiki">github page</a>.
+you can report them by visiting this <a href="https://github.com/RalphBayer/ConWiki">GitHub page</a>.
 Once at the site you can open a issue, and I will try to
 fix it as soon as possible.
 
 However, you can also try to fix these problems your self by
 contributing to the code that makes up ConWiki on the same
-<a href="https://github.com/RalphBayer/ConWiki">github page</a>. Even suggestions or ideas for how to improve
+<a href="https://github.com/RalphBayer/ConWiki">GitHub page</a>. Even suggestions or ideas for how to improve
 ConWiki are always welcome.
         </pre>
       </div>
@@ -73,7 +73,7 @@ after that you are free to edit the article as much as you want.
 To add style to your article such as: links, images, headings etc.
 ConWiki has specific keywords to add these. If you already know
 how styling works in wikipedia then most of the syntax will remain
-the same. For more help, please visit the <a href="https://github.com/RalphBayer/ConWiki">github page</a>
+the same. For more help, please visit the <a href="https://github.com/RalphBayer/ConWiki">GitHub page</a>
 where you will find full documentation for styling.
           </pre>
 


### PR DESCRIPTION
this changes “github” to “GitHub” except for where it’s part of an address.